### PR TITLE
Updated README.md; sinteractive is configurable to non-RIT setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 Interactive shell with X11 forwarding for SLURM.
 
-
-Run srun.x11 with the usual sbatch arguments, but DO NOT give a program to run.
-When your job starts, you'll find yourself usng an interactive shell which has
-proper X11 forwarding enabled.
-
+Run sinteractive. It will prompt you for arguments. Done.
+When your job starts, you'll find yourself using a screen session with
+X-forwarding enabled.
 
 == Author & Credits ==
 
@@ -14,4 +12,6 @@ Scripts were written by  Pär Andersson (National Supercomputer Centre, Sweden)
 and published in the SLURM FAQ.
 
 Small changes made by Paul Mezzanini - 2012
+
+More changes made by Josh McSavaney - 2014, 2015
 ==

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-== PURPOSE & USAGE ==
+##PURPOSE & USAGE
 
 Interactive shell with X11 forwarding for SLURM.
 
-Run sinteractive. It will prompt you for arguments. Done.
-When your job starts, you'll find yourself using a screen session with
-X-forwarding enabled.
+Run sinteractive. It will prompt you for resources allocation values
+using default values expressed in sinteractive.conf.
+When your job starts, you'll find yourself in an X-forwarded screen(1)
+session with a helpful splash message displayed.
 
-== Author & Credits ==
+##Author & Credits
 
-Scripts were written by  Pär Andersson (National Supercomputer Centre, Sweden)
+Scripts were originally written by  Pär Andersson (National Supercomputer Centre, Sweden)
 and published in the SLURM FAQ.
 
-Small changes made by Paul Mezzanini - 2012
+Small changes made by Paul Mezzanini (Rochester Institute of Technology) - 2012
 
-More changes made by Josh McSavaney - 2014, 2015
-==
+More significant changes made by Josh McSavaney (Rochester Institute of Technology) - 2014, 2015

--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ using default values expressed in sinteractive.conf.
 When your job starts, you'll find yourself in an X-forwarded screen(1)
 session with a helpful splash message displayed.
 
+You can tweak default values and some other config options with the included sinteractive.conf file.
+These config options can also be overwritten by a user's ~/.sinteractive.conf file.
+
+###REQUIREMENTS
+* SLURM utilities installed on the target system
+* gnu screen
+ * scheduled and then sinteractive attachs to it
+* htop (recommended)
+ * started as a default tab in screen
+ * can be omitted if you remove the htop line from sinteractive_screenrc.conf
+* users must be able to SSH to compute nodes
+
+###INSTALLATION
+
+Ensure that all of the files (sans README.md) in this repo exist in the _same_ directory. It's advisable to have this directory exist in PATH. If you're just a user, you can just clone the repo somewhere in your home directory and run it from there since sinteractive doesn't really require anything privileged or fancy.
+
 ##Author & Credits
 
 Scripts were originally written by  Pär Andersson (National Supercomputer Centre, Sweden)

--- a/_interactive_screen
+++ b/_interactive_screen
@@ -9,9 +9,10 @@ SCREENSESSION="$1"
 # If DISPLAY is set then set that in the screen, then create a new
 # window with that environment and kill the old one.
 if [ "$DISPLAY" != "" ];then
-    screen -p2 -S "$SCREENSESSION" -X unsetenv DISPLAY
-    screen -p2 -S "$SCREENSESSION" -X setenv DISPLAY "$DISPLAY"
+    screen -S "$SCREENSESSION" -X unsetenv DISPLAY
+    screen -S "$SCREENSESSION" -X setenv DISPLAY "$DISPLAY"
 fi
 
-screen -p2 -S "$SCREENSESSION" -X kill #META tab has outlived its usefulness
+screen -p0 -S "$SCREENSESSION" -X kill #META tab has outlived its usefulness
+screen -S "$SCREENSESSION" -X screen -t "BASH" 0 bash
 exec screen -p1 -S "$SCREENSESSION" -rd

--- a/sinteractive
+++ b/sinteractive
@@ -14,7 +14,8 @@ set -e
 function TPUT()
 {
     #check for TTY and tput and redefine our existence based upon the results
-    if [[ -t 1 && -t 2 ]] && command -v "tput" >& /dev/null ; then
+    if [[ -t 1 && -t 2 ]] && command -v "tput" >& /dev/null \
+               && tput setaf 1 >& /dev/null ; then
         function TPUT()
         {
             tput "$@"

--- a/sinteractive
+++ b/sinteractive
@@ -57,6 +57,7 @@ function INFO()
 function READ_CONFIG()
 {
     [[ -r "$MYDIR"/sinteractive.conf ]] && . "$MYDIR"/sinteractive.conf
+    [[ -r ~/.sinteractive.conf ]] && . ~/.sinteractive.conf
     DEFCPU="${DEFCPU:=2}"
     DEFMEM="${DEFMEM:=4096}"
     DEFTIME="${DEFTIME:=120}"

--- a/sinteractive
+++ b/sinteractive
@@ -54,20 +54,39 @@ function INFO()
     TPUT sgr0
 }
 
+function READ_CONFIG()
+{
+    [[ -r "$MYDIR"/sinteractive.conf ]] && . "$MYDIR"/sinteractive.conf
+    DEFCPU="${DEFCPU:=2}"
+    DEFMEM="${DEFMEM:=4096}"
+    DEFTIME="${DEFTIME:=120}"
+    USE_QOS="${USE_QOS:=no}"
+    if [[ "$USE_QOS" = "yes" ]]; then
+        DEFQOS="${DEFQOS:=free}"
+    fi
+    DEFPART="${DEFPART:=work}"
+    TIMEOUT="${TIMEOUT:=60}"
+}
+
 export MYDIR="$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )" )"
 
 # Batch Script that starts SCREEN
 BS="${MYDIR}/_interactive"
 # Interactive screen script
 IS="${MYDIR}/_interactive_screen"
+READ_CONFIG
 
 INFO ">Please enter your resource requirements.<"
 echo " "
-read -e -p "How many CPU cores? :: " -i "2" REQCPU
-read -e -p "How much memory (in MB)? :: " -i "4096" REQMEM
-read -e -p "How many minutes do you need? :: " -i "120" REQTIME
-read -e -p "What QOS? :: " -i "free" QOS
-read -e -p "What partition? :: " -i "work" PARTITION
+read -e -p "How many CPU cores? :: " -i "$DEFCPU" REQCPU
+read -e -p "How much memory (in MB)? :: " -i "$DEFMEM" REQMEM
+read -e -p "How many minutes do you need? :: " -i "$DEFTIME" REQTIME
+
+if [[ $USE_QOS = "yes" ]]; then
+    read -e -p "What QOS? :: " -i "$DEFQOS" QOS
+fi
+
+read -e -p "What partition? :: " -i "$DEFPART" PARTITION
 
 echo " "
 
@@ -80,16 +99,28 @@ INFO "Spawning job with the following resources:"
 INFO "     Processors: ${REQCPU}"
 INFO "         Memory: ${REQMEM} MB"
 INFO "  Runtime limit: ${REQTIME} minutes"
-INFO "            QOS: ${QOS}"
+
+if [[ $USE_QOS = "yes" ]]; then
+    INFO "            QOS: ${QOS}"
+fi
+
 INFO "      Partition: ${PARTITION}"
+
+#declare SBATCH_ARGS as an array
+declare -a SBATCH_ARGS
+
+SBATCH_ARGS=( --cpus-per-task="${REQCPU}" --mem="${REQMEM}" \
+    --time="${REQTIME}" --partition="${PARTITION}"\
+    --output=/dev/null --error=/dev/null --export MYDIR )
+
+if [[ $USE_QOS = "yes" ]]; then
+    SBATCH_ARGS+=( --qos="${QOS}" )
+fi
 
 echo " "
 
 INFO "Submitting job..."
-# Submit the job and get the job id
-if ! JOB="$( sbatch --cpus-per-task="${REQCPU}" --mem="${REQMEM}" \
-    --time="${REQTIME}" --qos="${QOS}" --partition="${PARTITION}"\
-    --output=/dev/null --error=/dev/null --export MYDIR "$@" "${BS}" \
+if ! JOB="$( sbatch "${SBATCH_ARGS[@]}" "$@" "${BS}" \
     |& egrep -o -e "\b[0-9]+$" )"; then
 
     ERROR "Failed to create job. Please double-check all settings are valid."
@@ -109,7 +140,6 @@ if scontrol show job "$JOB" 2>/dev/null | grep -q "JobState=FAILED"; then
     exit 1
 fi
 
-TIMEOUT="60"
 INFO "Waiting for JOBID ${JOB} to start"
 while : ; do
     sleep 1s

--- a/sinteractive.conf
+++ b/sinteractive.conf
@@ -1,0 +1,24 @@
+#!/bin/bash
+#This is just sourced by a BASH script for config values
+
+#default number of CPU cores requested
+DEFCPU="2"
+
+#default amount of memory requested in MB
+DEFMEM="4096"
+
+#default number of minutes of runtime requested
+DEFTIME="120"
+
+#does our setup use QOS's? If, so then 'yes'
+USE_QOS="yes"
+
+#if USE_QOS != "yes", this is ignored
+#if USE_QOS = "yes" what is our default QOS?
+DEFQOS="free" #omit this if USE_QOS != yes
+
+#default partition to submit to
+DEFPART="work"
+
+#how many seconds to wait for a job to start
+TIMEOUT="60"

--- a/sinteractive_screenrc.conf
+++ b/sinteractive_screenrc.conf
@@ -7,9 +7,8 @@ altscreen on
 
 # Windows opening by default
 screen -t "HTOP" 9 htop
-screen -t "BASH" 0 bash
+screen -t "META" 0 bash #so we can send commands through with _interactive_screen and not stomp on other tabs
 screen -t "SPLASH" 1 _interactive_splash
-screen -t "META" 2 bash #so we can send commands through with _interactive_screen and not stomp on other tabs
 
 # Do not show startup message
 startup_message off


### PR DESCRIPTION
If we want this to be accepted upstream (which we do), then we want to keep it as setup-agnostic as possible. These changes define configuration files that allow for this. Also, the README has been updated.
